### PR TITLE
Improve/detect fallback source

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ to use a polyfill library, like [picturefill](https://github.com/scottjehl/pictu
 The component accepts the following inputs:
 
 - `sources` An array of sources (`{width: number, src: string}`)
-- `fallbackSource` The default image source
+- `fallbackSource` The default image source. If not set, it will be the smallest source from the `sources` array
 - `alt` The alt-attribute value of the image
 
 ## License

--- a/src/app/mm-responsive-image.component.spec.ts
+++ b/src/app/mm-responsive-image.component.spec.ts
@@ -71,6 +71,20 @@ describe('MmResponsiveImageComponent', () => {
             expect(component.sources[2].width).toBe(600);
             expect(component.sources[3].width).toBe(400);
         });
+
+        it('should take the smallest image as the ::fallbackSource if it was not set explicitly', () => {
+            component.sources = sourcesMock;
+
+            component.ngOnChanges();
+
+            expect(component.fallbackSource).toBe(component.sources[3].src);
+        });
+
+        it('should not set the ::fallbackSource if there are not ::sources', () => {
+            component.ngOnChanges();
+
+            expect(component.fallbackSource).toBe('');
+        });
     });
 
     it('should have a picture element with sources from the ::sources property', () => {

--- a/src/app/mm-responsive-image.component.spec.ts
+++ b/src/app/mm-responsive-image.component.spec.ts
@@ -80,7 +80,7 @@ describe('MmResponsiveImageComponent', () => {
             expect(component.fallbackSource).toBe(component.sources[3].src);
         });
 
-        it('should not set the ::fallbackSource if there are not ::sources', () => {
+        it('should not set the ::fallbackSource if there are no ::sources', () => {
             component.ngOnChanges();
 
             expect(component.fallbackSource).toBe('');

--- a/src/app/mm-responsive-image.component.ts
+++ b/src/app/mm-responsive-image.component.ts
@@ -21,6 +21,7 @@ export class MmResponsiveImageComponent implements OnChanges {
 
     /**
      * Fallback image source
+     * If not set, it will be the smallest source from the ::sources array
      *
      * @type {string}
      */
@@ -38,5 +39,9 @@ export class MmResponsiveImageComponent implements OnChanges {
      */
     ngOnChanges() {
         this.sources.sort((a: ResponsiveImageInterface, b: ResponsiveImageInterface) => b.width - a.width);
+
+        if (!this.fallbackSource && this.sources.length) {
+            this.fallbackSource = this.sources[(this.sources.length - 1)].src;
+        }
     }
 }


### PR DESCRIPTION
Use the source configured for the smallest width as the `::fallbackSource` if it is not set explicitly.